### PR TITLE
Don't delete docs when uploading docs with shared prefix

### DIFF
--- a/lib/hexdocs/queue.ex
+++ b/lib/hexdocs/queue.ex
@@ -139,6 +139,7 @@ defmodule Hexdocs.Queue do
 
   defp handle_record(%{"eventName" => "ObjectRemoved:" <> _, "s3" => s3}) do
     key = s3["object"]["key"]
+    start = System.os_time(:millisecond)
     Logger.info("OBJECT DELETED #{key}")
 
     case key_components(key) do
@@ -147,7 +148,9 @@ defmodule Hexdocs.Queue do
         all_versions = all_versions(repository, package)
         Hexdocs.Bucket.delete(repository, package, version, all_versions)
         update_index_sitemap(repository, key)
-        Logger.info("FINISHED DELETING DOCS #{key}")
+
+        elapsed = System.os_time(:millisecond) - start
+        Logger.info("FINISHED DELETING DOCS #{key} #{elapsed}ms")
         :ok
 
       {:ok, _repository, _package, _version} ->

--- a/test/hexdocs/bucket_test.exs
+++ b/test/hexdocs/bucket_test.exs
@@ -52,6 +52,25 @@ defmodule Hexdocs.BucketTest do
     refute Store.get(@bucket, "buckettest/#{test}/remove.html")
   end
 
+  test "dont overwrite package which same prefix name", %{test: test} do
+    version = Version.parse!("0.0.1")
+    test = Atom.to_string(test)
+    prefix_name = String.slice(test, -1000, String.length(test) - 1)
+
+    Bucket.upload("buckettest", "#{test}", version, [], [
+      {"file2", ""}
+    ])
+
+    Bucket.upload("buckettest", "#{prefix_name}", version, [], [
+      {"file1", ""}
+    ])
+
+    assert Store.get(@bucket, "buckettest/#{prefix_name}/file1")
+    assert Store.get(@bucket, "buckettest/#{prefix_name}/#{version}/file1")
+    assert Store.get(@bucket, "buckettest/#{test}/file2")
+    assert Store.get(@bucket, "buckettest/#{test}/#{version}/file2")
+  end
+
   test "newer beta docs do not overwrite stable main docs", %{test: test} do
     first = Version.parse!("0.5.0")
     second = Version.parse!("1.0.0-beta")


### PR DESCRIPTION
Private packages with a shared prefix, such that ecto is a prefix of ecto_sql, would delete the docs of ecto_sql when ecto was uploaded. This is because we list bucket files by prefix so that ecto/ would list all files under the ecto directory. The trailing / was removed by Path.join so we would also list the files of ecto_sql. This was only happened for private packages.

Closes hexpm/hexpm#1252.