### PR TITLE
Add latest flag to docs_config.js

### DIFF
--- a/lib/hexdocs/bucket.ex
+++ b/lib/hexdocs/bucket.ex
@@ -81,7 +81,8 @@ defmodule Hexdocs.Bucket do
       for version <- versions do
         %{
           version: "v#{version}",
-          url: Hexdocs.Utils.hexdocs_url(repository, "/#{package}/#{version}")
+          url: Hexdocs.Utils.hexdocs_url(repository, "/#{package}/#{version}"),
+          latest: Hexdocs.Utils.latest_version?(package, version, versions)
         }
       end
 

--- a/test/hexdocs/queue_test.exs
+++ b/test/hexdocs/queue_test.exs
@@ -255,11 +255,13 @@ defmodule Hexdocs.QueueTest do
       assert Jason.decode!(json) == [
                %{
                  "url" => "http://localhost/#{URI.encode(Atom.to_string(test))}/3.0.0",
-                 "version" => "v3.0.0"
+                 "version" => "v3.0.0",
+                 "latest" => true
                },
                %{
                  "url" => "http://localhost/#{URI.encode(Atom.to_string(test))}/1.0.0",
-                 "version" => "v1.0.0"
+                 "version" => "v1.0.0",
+                 "latest" => false
                }
              ]
     end


### PR DESCRIPTION
Hello there!

It's a common problem to find old docs surfacing at the top of search results - see for example https://x.com/jskalc/status/1816920900660236370. Maybe there are tricks that would improve the search rankings, but as a starting point, I thought it would be useful to warn users when they are looking at old versions, which some languages' docs systems already do.

The main PR for that is https://github.com/elixir-lang/ex_doc/pull/1918 - but it needs the docs host, i.e. hexdocs, to flag the latest version in docs_config.js. This PR does that.