### PR TITLE
Fix Req streaming by using response.body.ref

### DIFF
--- a/lib/hexdocs/http.ex
+++ b/lib/hexdocs/http.ex
@@ -27,7 +27,7 @@ defmodule Hexdocs.HTTP do
   def get_stream(url, headers) do
     case Req.get(url, headers: headers, retry: false, decode_body: false, into: :self) do
       {:ok, response} ->
-        stream = stream_body(response.body)
+        stream = stream_body(response.body.ref)
         {:ok, response.status, normalize_headers(response.headers), stream}
 
       {:error, reason} ->


### PR DESCRIPTION
With Req's `into: :self`, the response body is a `Req.Response.Async` struct, not a ref directly. Extract the ref field to match messages correctly in the receive block.