### PR TITLE
Fix open redirect vulnerability in OAuth return path

### DIFF
--- a/lib/hexdocs/plug.ex
+++ b/lib/hexdocs/plug.ex
@@ -97,7 +97,7 @@ defmodule Hexdocs.Plug do
     conn
     |> put_session("oauth_code_verifier", code_verifier)
     |> put_session("oauth_state", state)
-    |> put_session("oauth_return_path", conn.request_path)
+    |> put_session("oauth_return_path", safe_return_path(conn.request_path))
     |> redirect(url)
   end
 
@@ -361,6 +361,16 @@ defmodule Hexdocs.Plug do
       end
     end)
   end
+
+  defp safe_return_path("/" <> rest = path) do
+    if String.starts_with?(rest, "/") do
+      "/"
+    else
+      path
+    end
+  end
+
+  defp safe_return_path(_), do: "/"
 
   defp redirect(conn, url) do
     html = Plug.HTML.html_escape(url)

--- a/test/hexdocs/plug_test.exs
+++ b/test/hexdocs/plug_test.exs
@@ -38,6 +38,24 @@ defmodule Hexdocs.PlugTest do
       assert get_session(conn, "oauth_return_path") == "/foo"
     end
 
+    test "sanitize protocol-relative return path to prevent open redirect" do
+      conn = conn(:get, "http://plugtest.localhost:5002//evil.com") |> call()
+      assert conn.status == 302
+      assert get_session(conn, "oauth_return_path") == "/"
+    end
+
+    test "sanitize protocol-relative return path with extra slashes" do
+      conn = conn(:get, "http://plugtest.localhost:5002///evil.com/foo") |> call()
+      assert conn.status == 302
+      assert get_session(conn, "oauth_return_path") == "/"
+    end
+
+    test "preserve valid return path" do
+      conn = conn(:get, "http://plugtest.localhost:5002/some/path") |> call()
+      assert conn.status == 302
+      assert get_session(conn, "oauth_return_path") == "/some/path"
+    end
+
     test "OAuth callback with invalid state returns error" do
       conn =
         conn(:get, "http://plugtest.localhost:5002/oauth/callback?code=abc&state=wrong")


### PR DESCRIPTION
Validate that the OAuth return path stored in the session is a safe relative path. Protocol-relative URLs (e.g. //evil.com) are rejected and replaced with "/" to prevent redirecting users to external domains after the OAuth flow completes.