### PR TITLE
Add security headers to private hexdocs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,4 +155,4 @@ jobs:
         run: |
           docker buildx imagetools create \
             -t gcr.io/${PROJECT_ID}/${IMAGE_NAME}:${COMMIT_SHORT_SHA} \
-            $(printf 'gcr.io/${PROJECT_ID}/${IMAGE_NAME}@sha256:%s ' *)
+            $(printf "gcr.io/${PROJECT_ID}/${IMAGE_NAME}@sha256:%s " *)

--- a/lib/hexdocs/plug.ex
+++ b/lib/hexdocs/plug.ex
@@ -36,6 +36,8 @@ defmodule Hexdocs.Plug do
     plug(Plug.SSL, rewrite_on: [:x_forwarded_proto])
   end
 
+  plug(:security_headers)
+
   # TODO: Use MFAs
   plug(Plug.Session,
     store: :cookie,
@@ -52,6 +54,13 @@ defmodule Hexdocs.Plug do
   plug(:fetch_session)
   plug(:fetch_query_params)
   plug(:run)
+
+  defp security_headers(conn, _opts) do
+    conn
+    |> put_resp_header("x-content-type-options", "nosniff")
+    |> put_resp_header("x-frame-options", "SAMEORIGIN")
+    |> put_resp_header("referrer-policy", "strict-origin-when-cross-origin")
+  end
 
   defp put_secret_key_base(conn, _opts) do
     put_in(conn.secret_key_base, Application.get_env(:hexdocs, :session_key_base))

--- a/test/hexdocs/plug_test.exs
+++ b/test/hexdocs/plug_test.exs
@@ -343,6 +343,14 @@ defmodule Hexdocs.PlugTest do
     end
   end
 
+  test "sets security headers" do
+    conn = conn(:get, "http://localhost:5002/foo") |> call()
+
+    assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+    assert get_resp_header(conn, "x-frame-options") == ["SAMEORIGIN"]
+    assert get_resp_header(conn, "referrer-policy") == ["strict-origin-when-cross-origin"]
+  end
+
   defp call(conn) do
     Hexdocs.Plug.call(conn, [])
   end

--- a/test/hexdocs/tmp_dir_test.exs
+++ b/test/hexdocs/tmp_dir_test.exs
@@ -22,8 +22,9 @@ defmodule Hexdocs.TmpDirTest do
         send(test_pid, {:paths, file, dir})
       end)
 
+    ref = Process.monitor(task_pid)
     assert_receive {:paths, file, dir}
-    wait_for_cleanup(task_pid)
+    wait_for_cleanup(task_pid, ref)
 
     refute File.exists?(file)
     refute File.exists?(dir)
@@ -41,8 +42,9 @@ defmodule Hexdocs.TmpDirTest do
         raise "crash"
       end)
 
+    ref = Process.monitor(task_pid)
     assert_receive {:paths, file, dir}
-    wait_for_cleanup(task_pid)
+    wait_for_cleanup(task_pid, ref)
 
     refute File.exists?(file)
     refute File.exists?(dir)
@@ -63,8 +65,9 @@ defmodule Hexdocs.TmpDirTest do
         send(test_pid, {:paths, paths})
       end)
 
+    ref = Process.monitor(task_pid)
     assert_receive {:paths, paths}
-    wait_for_cleanup(task_pid)
+    wait_for_cleanup(task_pid, ref)
 
     for {file, dir} <- paths do
       refute File.exists?(file)
@@ -80,9 +83,8 @@ defmodule Hexdocs.TmpDirTest do
     assert File.dir?(dir)
   end
 
-  defp wait_for_cleanup(task_pid) do
-    ref = Process.monitor(task_pid)
-    assert_receive {:DOWN, ^ref, :process, ^task_pid, _}
+  defp wait_for_cleanup(task_pid, ref) do
+    assert_receive {:DOWN, ^ref, :process, ^task_pid, _}, 5000
     # Sync with the GenServer to ensure the :DOWN cleanup has been processed
     :sys.get_state(Hexdocs.TmpDir)
   end


### PR DESCRIPTION
Set x-content-type-options, x-frame-options, and referrer-policy headers matching the Fastly CDN configuration for public docs.