### PR TITLE
Redirect bare private host apex to hexpm_url

### DIFF
--- a/lib/hexdocs/plug.ex
+++ b/lib/hexdocs/plug.ex
@@ -67,24 +67,39 @@ defmodule Hexdocs.Plug do
   end
 
   defp run(conn, _opts) do
-    case subdomain(conn.host) do
-      :error ->
-        send_resp(conn, 400, "")
+    if conn.host == Application.get_env(:hexdocs, :private_host) do
+      redirect_to_hexpm(conn)
+    else
+      case subdomain(conn.host) do
+        :error ->
+          send_resp(conn, 400, "")
 
-      {:ok, subdomain} ->
-        cond do
-          # OAuth callback - exchange code for tokens
-          conn.request_path == "/oauth/callback" ->
-            handle_oauth_callback(conn, subdomain)
+        {:ok, subdomain} ->
+          cond do
+            # OAuth callback - exchange code for tokens
+            conn.request_path == "/oauth/callback" ->
+              handle_oauth_callback(conn, subdomain)
 
-          # OAuth access token in session
-          access_token = get_session(conn, "access_token") ->
-            try_serve_page_oauth(conn, subdomain, access_token)
+            # OAuth access token in session
+            access_token = get_session(conn, "access_token") ->
+              try_serve_page_oauth(conn, subdomain, access_token)
 
-          true ->
-            redirect_oauth(conn, subdomain)
-        end
+            true ->
+              redirect_oauth(conn, subdomain)
+          end
+      end
     end
+  end
+
+  defp redirect_to_hexpm(conn) do
+    url = Application.get_env(:hexdocs, :hexpm_url)
+    html = Plug.HTML.html_escape(url)
+    body = "<html><body>You are being <a href=\"#{html}\">redirected</a>.</body></html>"
+
+    conn
+    |> put_resp_header("location", url)
+    |> put_resp_header("content-type", "text/html")
+    |> send_resp(301, body)
   end
 
   defp redirect_oauth(conn, organization) do

--- a/test/hexdocs/plug_test.exs
+++ b/test/hexdocs/plug_test.exs
@@ -9,9 +9,13 @@ defmodule Hexdocs.PlugTest do
 
   @bucket :docs_private_bucket
 
-  test "requests without subdomain not supported" do
+  test "bare private host apex redirects to hexpm_url" do
+    # In the test env :host and :private_host are both "localhost", so a
+    # bare-host request hits the private-host-apex redirect.
     conn = conn(:get, "http://localhost:5002/foo") |> call()
-    assert conn.status == 400
+    assert conn.status == 301
+    [location] = get_resp_header(conn, "location")
+    assert location == "http://localhost:5000"
   end
 
   describe "OAuth flow" do
@@ -339,6 +343,13 @@ defmodule Hexdocs.PlugTest do
 
       conn = conn(:get, "http://phoenix.hexdocs.test:5002/index.html") |> call()
       assert conn.status == 400
+    end
+
+    test "redirects bare private host apex to hexpm_url" do
+      conn = conn(:get, "http://hexorgs.test:5002/") |> call()
+      assert conn.status == 301
+      [location] = get_resp_header(conn, "location")
+      assert location == "http://localhost:5000"
     end
   end
 


### PR DESCRIPTION
`hexorgs.pm` (prod) and `staging.hexorgs.pm` (staging) have no apex DNS record today and currently fall through to the subdomain validator's `:error` branch when reached. Add an explicit branch at the top of `run/2`: if `conn.host == private_host`, 301 to the configured `hexpm_url`.

  prod:    hexorgs.pm           -> https://hex.pm
  staging: staging.hexorgs.pm   -> https://staging.hex.pm

The previous "requests without subdomain not supported" test on bare `localhost` is rewritten to assert the new 301 behaviour (test config has `:private_host` set to `localhost`, so bare `localhost` is the private-host-apex case).

**Depends on** a Cloudflare DNS record being added for the hexorgs.pm apex (and `staging.hexorgs.pm`) pointing at the GKE ingress so requests reach the app. That goes in a separate hexpm-ops PR.