### PR TITLE
Include special packages in package_names.csv

### DIFF
--- a/lib/hexdocs/queue.ex
+++ b/lib/hexdocs/queue.ex
@@ -362,6 +362,7 @@ defmodule Hexdocs.Queue do
 
     case Hexdocs.HexRepo.get_names() do
       {:ok, names} ->
+        names = Enum.sort(@special_package_names) ++ names
         csv = for name <- names, do: [name, "\n"]
         Hexdocs.Bucket.upload_package_names_csv(csv)
 

--- a/test/hexdocs/queue_test.exs
+++ b/test/hexdocs/queue_test.exs
@@ -77,7 +77,15 @@ defmodule Hexdocs.QueueTest do
 
       assert Store.get(@public_bucket, "#{test}/index.html") == "contents"
       assert Store.get(@public_bucket, "#{test}/1.0.0/index.html") == "contents"
-      assert Store.get(@public_bucket, "package_names.csv") == "package1\npackage2\n"
+      names = Store.get(@public_bucket, "package_names.csv") |> String.split("\n", trim: true)
+      assert "package1" in names
+      assert "package2" in names
+
+      special_packages = Map.keys(Application.fetch_env!(:hexdocs, :special_packages))
+
+      for package <- special_packages do
+        assert package in names
+      end
     end
 
     test "overwrite main docs with newer versions", %{test: test} do


### PR DESCRIPTION
The package_names.csv published to hexdocs.pm was generated solely from the Hex registry names, so the Elixir standard library applications and Hex itself (the special packages, which are documented on hexdocs.pm but not published as Hex packages) were absent. Consumers such as the hexdocs search autocomplete therefore could not list them.

Prepend the configured special package names so the file reflects the same authoritative set the rest of the producer uses.