### PR TITLE
Purge the private docs Fastly service for private repositories

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -12,6 +12,7 @@ if config_env() == :prod do
     typesense_collection: System.fetch_env!("HEXDOCS_TYPESENSE_COLLECTION"),
     fastly_key: System.fetch_env!("HEXDOCS_FASTLY_KEY"),
     fastly_hexdocs: System.fetch_env!("HEXDOCS_FASTLY_HEXDOCS"),
+    fastly_hexdocs_private: System.fetch_env!("HEXDOCS_FASTLY_HEXDOCS_PRIVATE"),
     queue_id: System.fetch_env!("HEXDOCS_QUEUE_ID"),
     session_key_base: System.fetch_env!("HEXDOCS_SESSION_KEY_BASE"),
     session_signing_salt: System.fetch_env!("HEXDOCS_SESSION_SIGNING_SALT"),

--- a/lib/hexdocs/bucket.ex
+++ b/lib/hexdocs/bucket.ex
@@ -34,7 +34,7 @@ defmodule Hexdocs.Bucket do
         :ok
     end
 
-    purge([key])
+    purge("hexpm", [key])
   end
 
   def upload(repository, package, version, all_versions, retired_versions, dir, files) do
@@ -67,7 +67,7 @@ defmodule Hexdocs.Bucket do
     )
 
     purge_hexdocs_cache(repository, package, [version], upload_type)
-    purge([docs_config_cdn_key(repository, package)])
+    purge(repository, [docs_config_cdn_key(repository, package)])
   end
 
   # For Elixir and Hex we use the docs_config.js included in the tarball
@@ -331,19 +331,14 @@ defmodule Hexdocs.Bucket do
   # Don't use Path.join as it removes trailing / which is needed for bucket listing
   defp repository_path(repository, path), do: Enum.join([repository, "/", path])
 
-  defp purge_hexdocs_cache("hexpm", package, versions, :both) do
-    keys = Enum.map(versions, &docspage_versioned_cdn_key("hexpm", package, &1))
-    purge([docspage_unversioned_cdn_key("hexpm", package)] ++ keys)
+  defp purge_hexdocs_cache(repository, package, versions, :both) do
+    keys = Enum.map(versions, &docspage_versioned_cdn_key(repository, package, &1))
+    purge(repository, [docspage_unversioned_cdn_key(repository, package)] ++ keys)
   end
 
-  defp purge_hexdocs_cache("hexpm", package, versions, :versioned) do
-    versions
-    |> Enum.map(&docspage_versioned_cdn_key("hexpm", package, &1))
-    |> purge()
-  end
-
-  defp purge_hexdocs_cache(_repository, _package, _version, _publish_unversioned?) do
-    :ok
+  defp purge_hexdocs_cache(repository, package, versions, :versioned) do
+    keys = Enum.map(versions, &docspage_versioned_cdn_key(repository, package, &1))
+    purge(repository, keys)
   end
 
   defp docspage_versioned_cdn_key(repository, package, version) do
@@ -363,9 +358,10 @@ defmodule Hexdocs.Bucket do
   defp public?("hexpm"), do: true
   defp public?(_), do: false
 
-  defp purge(keys) do
-    Logger.info("Purging fastly_hexdocs #{Enum.join(keys, " ")}")
-    Hexdocs.CDN.purge_key(:fastly_hexdocs, keys)
+  defp purge(repository, keys) do
+    service = if public?(repository), do: :fastly_hexdocs, else: :fastly_hexdocs_private
+    Logger.info("Purging #{service} #{Enum.join(keys, " ")}")
+    Hexdocs.CDN.purge_key(service, keys)
   end
 
   defp put(bucket, key, data, opts) do

--- a/lib/hexdocs/cdn/local.ex
+++ b/lib/hexdocs/cdn/local.ex
@@ -1,5 +1,8 @@
 defmodule Hexdocs.CDN.Local do
   @behaviour Hexdocs.CDN
 
-  def purge_key(_service, _key), do: :ok
+  def purge_key(service, key) do
+    send(self(), {:purge, service, key})
+    :ok
+  end
 end

--- a/test/hexdocs/bucket_test.exs
+++ b/test/hexdocs/bucket_test.exs
@@ -122,6 +122,26 @@ defmodule Hexdocs.BucketTest do
     assert Store.get(@bucket, "buckettest/#{test}/index.html") == "2.0.0-beta"
   end
 
+  test "publishing docs for a private repository purges the private docs service", %{test: test} do
+    version = Version.parse!("0.0.1")
+    {dir, files} = create_files([{"index.html", "0.0.1"}])
+    Bucket.upload("buckettest", "#{test}", version, [], MapSet.new(), dir, files)
+
+    assert_receive {:purge, :fastly_hexdocs_private, keys}
+    assert "docspage/buckettest-#{test}" in keys
+    refute_receive {:purge, :fastly_hexdocs, _keys}
+  end
+
+  test "publishing docs for the hexpm repository purges the public docs service", %{test: test} do
+    version = Version.parse!("0.0.1")
+    {dir, files} = create_files([{"index.html", "0.0.1"}])
+    Bucket.upload("hexpm", "#{test}", version, [], MapSet.new(), dir, files)
+
+    assert_receive {:purge, :fastly_hexdocs, keys}
+    assert "docspage/#{test}" in keys
+    refute_receive {:purge, :fastly_hexdocs_private, _keys}
+  end
+
   test "upload docs_config.js", %{test: test} do
     version = "1.0.0"
     all_versions = []


### PR DESCRIPTION
Makes hexdocs cache purging repository-aware. Private repositories' docs are now edge-cached by the new `docs-private` Fastly compute service, so publish/delete of private docs must purge that service (`:fastly_hexdocs_private`) rather than the public one. The public hexpm path is unchanged.

- `purge/2` selects `:fastly_hexdocs_private` for non-hexpm repositories via `public?/1`
- `purge_hexdocs_cache/4` is generalized from hardcoded `"hexpm"` to any repository
- `HEXDOCS_FASTLY_HEXDOCS_PRIVATE` (the prod docs-private service id) is wired into runtime config; the Fastly adapter resolves it generically
- the local CDN adapter records purges so both branches are covered by tests

Deploy ordering: the prod deployment config map must already provide `HEXDOCS_FASTLY_HEXDOCS_PRIVATE` (fail-fast on boot) — set via the hexpm-ops docs-private service.
