### PR TITLE
Raise informative errors for failed Fastly purges

### DIFF
--- a/lib/hexdocs/cdn/fastly.ex
+++ b/lib/hexdocs/cdn/fastly.ex
@@ -9,16 +9,27 @@ defmodule Hexdocs.CDN.Fastly do
     service_id = Application.get_env(:hexdocs, service)
     sleep_time = div(Application.get_env(:hexdocs, :fastly_purge_wait, @fastly_purge_wait), 2)
 
-    {:ok, 200, _, _} = post("service/#{service_id}/purge", body)
+    purge!(service, service_id, body)
 
     Task.Supervisor.start_child(Hexdocs.Tasks, fn ->
       Process.sleep(sleep_time)
-      {:ok, 200, _, _} = post("service/#{service_id}/purge", body)
+      purge!(service, service_id, body)
       Process.sleep(sleep_time)
-      {:ok, 200, _, _} = post("service/#{service_id}/purge", body)
+      purge!(service, service_id, body)
     end)
 
     :ok
+  end
+
+  defp purge!(service, service_id, body) do
+    case post("service/#{service_id}/purge", body) do
+      {:ok, 200, _headers, _body} ->
+        :ok
+
+      {:ok, status, _headers, body} ->
+        raise "failed to purge #{service} (service id: #{service_id}), " <>
+                "status: #{status}, body: #{inspect(body)}"
+    end
   end
 
   defp auth() do

--- a/lib/hexdocs/queue.ex
+++ b/lib/hexdocs/queue.ex
@@ -401,7 +401,7 @@ defmodule Hexdocs.Queue do
 
     case Task.yield(task, :timer.seconds(270)) || Task.shutdown(task) do
       {:ok, result} -> result
-      {:exit, {exception, stacktrace}} -> reraise(exception, stacktrace)
+      {:exit, {exception, stacktrace}} when is_exception(exception) -> reraise(exception, stacktrace)
       {:exit, reason} -> exit(reason)
       nil -> raise "task timeout"
     end

--- a/lib/hexdocs/queue.ex
+++ b/lib/hexdocs/queue.ex
@@ -400,10 +400,17 @@ defmodule Hexdocs.Queue do
     task = Task.Supervisor.async(Hexdocs.Tasks, fun)
 
     case Task.yield(task, :timer.seconds(270)) || Task.shutdown(task) do
-      {:ok, result} -> result
-      {:exit, {exception, stacktrace}} when is_exception(exception) -> reraise(exception, stacktrace)
-      {:exit, reason} -> exit(reason)
-      nil -> raise "task timeout"
+      {:ok, result} ->
+        result
+
+      {:exit, {exception, stacktrace}} when is_exception(exception) ->
+        reraise(exception, stacktrace)
+
+      {:exit, reason} ->
+        exit(reason)
+
+      nil ->
+        raise "task timeout"
     end
   end
 


### PR DESCRIPTION
Purges of the private docs service started failing after #137 went out, surfacing as a bare `MatchError` on the Fastly API's 404 response:

```
MatchError: no match of right hand side value: {:ok, 404, [...], %{"detail" => "Cannot find service", "msg" => "Record not found"}}
```

The root cause was the Fastly API token being scoped to services that didn't include the new docs-private compute service (fixed separately in hexpm-ops by rotating the token). This PR improves how hexdocs surfaces such failures:

- Non-200 purge responses now raise an error that includes the service name, service id, status, and response body, instead of a `MatchError` on the raw response tuple.
- Fixes a bug in `Queue.run_in_task/1`: task exit reasons like `{:badmatch, value}` are not exceptions, so passing them to `reraise/2` raised `ArgumentError: raise/1 and reraise/2 expect a module name, string or exception` and masked the original error. Exit reasons are now only reraised when they are actual exceptions; anything else exits with the original reason so the real failure is reported.